### PR TITLE
Projects from sonar are now sorted by name

### DIFF
--- a/metrics-collector/src/main/java/org/codeqinvest/sonar/ProjectInformation.java
+++ b/metrics-collector/src/main/java/org/codeqinvest/sonar/ProjectInformation.java
@@ -24,7 +24,7 @@ import lombok.Data;
  * @author fmueller
  */
 @Data
-public class ProjectInformation {
+public class ProjectInformation implements Comparable {
 
   private String name;
   private String resourceKey;
@@ -37,4 +37,15 @@ public class ProjectInformation {
     this.name = name;
     this.resourceKey = resourceKey;
   }
+
+    @Override
+    public int compareTo(Object o) {
+      if (o != null) {
+        ProjectInformation otherProjectInformation = (ProjectInformation) o;
+          if (otherProjectInformation.getName() != null && this.getName() != null) {
+            return this.name.compareToIgnoreCase(otherProjectInformation.getName());
+          }
+      }
+      return 1;
+    }
 }

--- a/metrics-collector/src/main/java/org/codeqinvest/sonar/ProjectsCollectorService.java
+++ b/metrics-collector/src/main/java/org/codeqinvest/sonar/ProjectsCollectorService.java
@@ -18,7 +18,6 @@
  */
 package org.codeqinvest.sonar;
 
-import com.google.common.collect.Sets;
 import org.sonar.wsclient.Sonar;
 import org.sonar.wsclient.connectors.HttpClient4Connector;
 import org.sonar.wsclient.services.Resource;
@@ -27,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * This service collects all projects that are
@@ -43,7 +43,7 @@ public class ProjectsCollectorService {
   public Set<ProjectInformation> collectAllProjects(SonarConnectionSettings connectionSettings) {
     Sonar sonar = new Sonar(new HttpClient4Connector(connectionSettings.asHostObject()));
     List<Resource> projectResources = sonar.findAll(new ResourceQuery().setLanguages("java"));
-    Set<ProjectInformation> projects = Sets.newHashSet();
+    Set<ProjectInformation> projects = new TreeSet<ProjectInformation>();
     for (Resource resource : projectResources) {
       projects.add(new ProjectInformation(resource.getName(), resource.getKey()));
     }

--- a/metrics-collector/src/test/java/org/codeqinvest/sonar/ProjectInformationTest.java
+++ b/metrics-collector/src/test/java/org/codeqinvest/sonar/ProjectInformationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 Felix Müller
+ *
+ * This file is part of CodeQ Invest.
+ *
+ * CodeQ Invest is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CodeQ Invest is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CodeQ Invest.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.codeqinvest.sonar;
+
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author oliver.wehrens
+ */
+public class ProjectInformationTest {
+
+  private ProjectInformation A = new ProjectInformation("A", "");
+  private ProjectInformation B = new ProjectInformation("B", "");
+  private ProjectInformation a = new ProjectInformation("a", "");
+  private ProjectInformation nullName = new ProjectInformation(null, "");
+
+  private int comesBefore = -1;
+  private int areTheSame = 0;
+  private int comesAfter = 1;
+
+  @Test
+  public void A_is_sorted_before_B() {
+    assertThat(A.compareTo(B)).isEqualTo(comesBefore);
+  }
+
+  @Test
+  public void a_is_sorted_before_B() {
+    assertThat(a.compareTo(B)).isEqualTo(comesBefore);
+  }
+
+  @Test
+  public void B_is_sorted_after_A() {
+    assertThat(B.compareTo(A)).isEqualTo(comesAfter);
+  }
+
+  @Test
+  public void A_and_a_are_the_same() {
+    assertThat(a.compareTo(A)).isEqualTo(areTheSame);
+  }
+
+  @Test
+  public void compared_to_null_is_the_same() {
+    assertThat(B.compareTo(null)).isEqualTo(comesAfter);
+  }
+
+  @Test
+  public void compared_to_null_name_is_sorted_after() {
+    assertThat(B.compareTo(nullName)).isEqualTo(comesAfter);
+  }
+
+  @Test
+  public void compared__valid_projectInfo_to_null_is_sorted_after() {
+    assertThat(nullName.compareTo(A)).isEqualTo(comesAfter);
+  }
+
+}


### PR DESCRIPTION
We have about 60ish projects in sonar and not haveing them sorted by something is not good. So I sort them by name.
